### PR TITLE
Update doc and spec files to define behavior of streams with or without object mode within a pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,11 +178,13 @@ function map<Input, Output>(mapFunction: (value: Input) => Output): Operator<Inp
 }
 ```
 
-It is straightforward to create custom operators, but it is important to note how they relate to streams:
-- returning (exiting) out of the function is equivalent to the `end` event of a stream.
-- `throw`-ing an error is equivalent to the `error` event of a stream.
-
-In either of these cases, the pipeline containing the operator will either complete or throw the error.
+It is straightforward to create custom operators, and mix with streams, but it is important to note how they relate to
+streams:
+- returning (exiting) out of the function is equivalent to the `end` event of a stream.  The pipeline will complete.
+- `throw`-ing an error is equivalent to the `error` event of a stream.  The pipeline will throw the error.
+- streams in object mode will swallow `undefined` values emitted by sources and prior operators.
+- streams in object mode will error on `null` values emitted by sources and prior operators.
+- non-object mode streams will error on any value that is not a string, Buffer or Uint8Array.
 
 ### `after<Input>(value: Input): Operator<Input, Input>`
 

--- a/src/node/pipeline.spec.ts
+++ b/src/node/pipeline.spec.ts
@@ -73,11 +73,24 @@ describe('pipeline', () => {
       name: 'TypeError',
       message: 'The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received undefined',
     });
-    await assert.rejects(async () => pipeline([1], new PassThrough({ objectMode: false }), toString), {
+    await assert.rejects(async () => pipeline([true], new PassThrough({ objectMode: false }), toString), {
       name: 'TypeError',
       message:
-        'The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received type number (1)',
+        'The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received type boolean (true)',
     });
+    await assert.rejects(async () => pipeline([{}], new PassThrough({ objectMode: false }), toString), {
+      name: 'TypeError',
+      message:
+        'The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received an instance of Object',
+    });
+    await assert.rejects(
+      async () => pipeline([Symbol.for('hello')], new PassThrough({ objectMode: false }), toString),
+      {
+        name: 'TypeError',
+        message:
+          'The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received type symbol (Symbol(hello))',
+      }
+    );
     await assert.rejects(async () => pipeline([1], new PassThrough({ objectMode: false }), toString), {
       name: 'TypeError',
       message:

--- a/src/node/pipeline.spec.ts
+++ b/src/node/pipeline.spec.ts
@@ -9,7 +9,7 @@
 /* eslint-disable deprecate/function */
 
 import assert from 'assert';
-import { Readable, Writable } from 'stream';
+import { PassThrough, Readable, Writable } from 'stream';
 
 import { toString } from '../sink';
 
@@ -58,6 +58,52 @@ describe('pipeline', () => {
     assert.strictEqual(await result1, 'undefined1null2true34,5,6,7');
     assert.strictEqual(await result2, '104101108108111');
     assert.strictEqual(await result3, 'hello');
+  });
+
+  it('works consistently with streams', async () => {
+    assert.deepStrictEqual(
+      await pipeline([undefined, 1, 2, true, 3, [4, [5], 6, 7]], new PassThrough({ objectMode: true }), toString),
+      '12true34,5,6,7'
+    );
+    await assert.rejects(async () => pipeline([null], new PassThrough({ objectMode: true }), toString), {
+      name: 'TypeError',
+      message: 'May not write null values to stream',
+    });
+    await assert.rejects(async () => pipeline([undefined], new PassThrough({ objectMode: false }), toString), {
+      name: 'TypeError',
+      message: 'The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received undefined',
+    });
+    await assert.rejects(async () => pipeline([1], new PassThrough({ objectMode: false }), toString), {
+      name: 'TypeError',
+      message:
+        'The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received type number (1)',
+    });
+    await assert.rejects(async () => pipeline([1], new PassThrough({ objectMode: false }), toString), {
+      name: 'TypeError',
+      message:
+        'The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received type number (1)',
+    });
+    await assert.rejects(async () => pipeline([1n], new PassThrough({ objectMode: false }), toString), {
+      name: 'TypeError',
+      message:
+        'The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received type bigint (1n)',
+    });
+    assert.deepStrictEqual(
+      await pipeline(
+        ['hello', Uint8Array.from([32]), Buffer.from('world')],
+        new PassThrough({ objectMode: true }),
+        toString
+      ),
+      'hello32world'
+    );
+    assert.deepStrictEqual(
+      await pipeline(
+        ['hello', Uint8Array.from([32]), Buffer.from('world')],
+        new PassThrough({ objectMode: false }),
+        toString
+      ),
+      'hello world'
+    );
   });
 
   it('returns ReadWriteStream if last parameter is an async generator', async () => {


### PR DESCRIPTION
Fixes #7.  In the end decided not to do any weird custom stuff, just documented and created a test case for current behavior.