### PR TITLE
Modified specs to match new node pipeline behavior

### DIFF
--- a/src/node/pipeline.spec.ts
+++ b/src/node/pipeline.spec.ts
@@ -50,7 +50,7 @@ describe('pipeline', () => {
     await assert.rejects(async () => pipeline(Buffer.from('crash'), passThru, toString));
   });
 
-  it('throws error if source is an empty string', async () => {
+  (process.version < 'v16' ? it : xit)('throws error if source is an empty string in Node < v16', async () => {
     // tracking this behavior in Node.  This is a bug in node stream.pipeline implementation:
     // https://github.com/nodejs/node/issues/38721
     await assert.rejects(async () => pipeline('', passThru, toString));


### PR DESCRIPTION
The tests were breaking in the latest version of node 16, was concerned the changes in Abort/pipeline behavior may impact connector.  Don't think so though, but have a look to see what it does now.